### PR TITLE
Whitelabeling 

### DIFF
--- a/charts/gardener-dashboard/charts/runtime/templates/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/configmap.yaml
@@ -15,16 +15,20 @@ metadata:
 data:
   login-config.json: |
     {
-       "landingPageUrl": {{ quote .Values.global.frontendConfig.landingPageUrl }},
-       "landingPageName": {{ quote .Values.global.frontendConfig.landingPageName }},
-       "customSubheader": {{ quote .Values.global.frontendConfig.customSubheader }},
-       "customLandingPagePre": {{ quote .Values.global.frontendConfig.customLandingPagePre }},
-       "customLandingPagePost": {{ quote .Values.global.frontendConfig.customLandingPagePost }},
-       {{- if .Values.global.oidc.enabled }}
-       "loginTypes": ["oidc", "token"]
-       {{- else }}
-       "loginTypes": ["token"]
-       {{- end }}
+      "productName": {{ quote .Values.global.frontendConfig.productName }},
+      "productSlogan": {{ quote .Values.global.frontendConfig.productSlogan }},
+      "documentationURL": {{ quote .Values.global.frontendConfig.documentationURL }},
+      "supportURL": {{ quote .Values.global.frontendConfig.supportURL }},
+      "landingPageUrl": {{ quote .Values.global.frontendConfig.landingPageUrl }},
+      "landingPageName": "{{ quote .Values.global.frontendConfig.landingPageName }},
+      "customLandingPagePre": {{ quote .Values.global.frontendConfig.customLandingPagePre }},
+      "customLandingPagePost": {{ quote .Values.global.frontendConfig.customLandingPagePost }},
+
+      {{- if .Values.global.oidc.enabled }}
+      "loginTypes": ["oidc", "token"]
+      {{- else }}
+      "loginTypes": ["token"]
+      {{- end }}
     }
   config.yaml: |
     ---

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -106,11 +106,16 @@ global:
       #   -----END RSA PRIVATE KEY-----
 
   frontendConfig:
-    landingPageUrl: https://plusserver.com/pske
-    landingPageName: PSKE Landing Page
-    customSubheader: Managed Kubernetes at Scale
-    customLandingPagePre: "Discover what our service is about at the "
-    customLandingPagePost: ""
+    productName": "PSKE",
+    productSlogan": "Managed Kubernetes at Scale",
+    documentationURL": "https://docs.pske.get-cloud.io",
+    supportURL": "https://www.plusserver.com/ueber-uns/plusserver-kontakt",
+    landingPageUrl": "https://plusserver.com/pske",
+    landingPageName": "Plusserver Kubernetes Engine",
+    customLandingPagePre": "Powered by",
+    customLandingPagePost": "",
+    loginTypes": ["token"]
+
     # # asset configuration (see https://github.com/gardener/dashboard/blob/master/docs/Theming.md#logos-and-icons for the format and generation of the default values).
     # assets:
     #   favicon-16x16.png: |

--- a/docs/whitelabeling.md
+++ b/docs/whitelabeling.md
@@ -13,6 +13,29 @@ Vue.js Theming options. For documentation see deployment/theming.md
 
 ## Logo
 The logo is served at `/static/assets/logo.svg` and can be found in the 
-source at `/frontend/public/static/assets/logo.svg`. You should be able
-to overwrite this with a Kubernetes Config Map when the dashboard is deployed.
+source at `/frontend/public/static/assets/logo.svg`. This is also changed
+with by the theming capabilities.
 
+## Customizing Product Name
+You can customize some values by providing a custom `login-config.json`.
+Available parameters are:
+```json
+{
+  "productName": "PSKE",
+  "productSlogan": "Managed Kubernetes at Scale",
+  "documentationURL": "https://docs.pske.get-cloud.io",
+  "supportURL": "https://www.plusserver.com/ueber-uns/plusserver-kontakt",
+  "landingPageUrl": "https://plusserver.com/pske",
+  "landingPageName": "Plusserver Kubernetes Engine",
+  "customLandingPagePre": "Powered by",
+  "loginTypes": ["token"]
+}
+```
+This file is found at `frontend/public/login-config.json` and served
+as `/login-config-json`. You can see all parameters in the source at
+`frontend/src/views/Login.vue`.
+
+To avoid uneccessary network latency, the `login-config.json` is fetched
+by the Login-Page only and the values are then copied in the Browsers
+sessionStorage. This means that during development you might have to 
+logout and login again to see the changes reflected on the rendered pages.

--- a/frontend/public/login-config.json
+++ b/frontend/public/login-config.json
@@ -1,7 +1,10 @@
 {
+  "productName": "PSKE",
+  "productSlogan": "Managed Kubernetes at Scale",
+  "documentationURL": "https://docs.pske.get-cloud.io",
+  "supportURL": "https://www.plusserver.com/ueber-uns/plusserver-kontakt",
   "landingPageUrl": "https://plusserver.com/pske",
   "landingPageName": "Plusserver Kubernetes Engine",
-  "customLandingPagePre": "Based on ",
-  "customSubheader": "Managed Kubernetes",
+  "customLandingPagePre": "Powered by",
   "loginTypes": ["token"]
 }

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: Apache-2.0
           </v-btn>
           <a href="/">
             <img src="/static/assets/logo.svg" class="logo" alt="gardener logo">
-            <h1 class="main-navigation-title--text">PSKE</h1>
-            <h2 class="primary--text">Managed Kubernetes at Scale</h2>
+            <h1 class="main-navigation-title--text">{{ productName }}</h1>
+            <h2 class="primary--text">{{ customSubheader }}</h2>
           </a>
         </div>
       </div>
@@ -204,6 +204,12 @@ export default {
     ]),
     version () {
       return get(this.cfg, 'appVersion', process.env.VUE_APP_VERSION)
+    },
+    productName () {
+      return sessionStorage.getItem('wl.productName') || 'PSKE'
+    },
+    customSubheader () {
+      return sessionStorage.getItem('wl.productSlogan') || 'Managed Kubernetes at Scale'
     },
     isActive: {
       get () {

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0
         </template>
         <v-card tile width="300px">
           <v-card-title primary-title>
-            <div class="content text-h6 mb-2">PSKE</div>
+            <div class="content text-h6 mb-2">{{ productName }}</div>
           </v-card-title>
           <v-divider></v-divider>
           <v-card-actions class="px-3">
@@ -242,6 +242,9 @@ export default {
     },
     settingsLink () {
       return this.targetRoute('Settings')
+    },
+    productName () {
+      return sessionStorage.getItem('wl.productName') || 'PSKE'
     },
     colorSchemeIndex: {
       get () {

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -15,9 +15,9 @@ SPDX-License-Identifier: Apache-2.0
     <template v-slot:caption>About</template>
     <template v-slot:message>
       <div class="d-flex flex-row align-center mt-3">
-        <img src="/static/assets/logo.svg" alt="gardener logo" class="logo mr-3">
+        <img src="/static/assets/logo.svg" alt="product logo" class="logo mr-3">
         <div>
-          <h2 class="mb-1">PSKE Dashboard</h2>
+          <h2 class="mb-1">{{ productName }} Dashboard</h2>
         </div>
       </div>
       <v-divider class="my-3"></v-divider>
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
         <div class="font-weight-bold">Version Information</div>
         <div v-if="!!dashboardVersion">Dashboard<span class="ml-1 font-weight-bold">{{dashboardVersion}}</span></div>
         <template v-if="isAdmin">
-          <div v-if="!!gardenerVersion">API<span class="ml-1 font-weight-bold">{{gardenerVersion}}</span></div>
+          <div v-if="!!gardenerVersion">Gardener API<span class="ml-1 font-weight-bold">{{gardenerVersion}}</span></div>
           <v-divider v-if="extensionsList.length" class="my-3"></v-divider>
           <div v-if="extensionsList.length" class="font-weight-bold">Extensions ({{extensionsList.length}} deployed)</div>
           <div
@@ -69,6 +69,9 @@ export default {
       'isAdmin',
       'gardenerExtensionsList'
     ]),
+    productName () {
+      return sessionStorage.getItem('wl.productName') || 'PSKE'
+    },
     extensionsList () {
       return sortBy(this.gardenerExtensionsList, 'name')
     }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -15,7 +15,8 @@ SPDX-License-Identifier: Apache-2.0
               <v-card-title class="pa-0">
                 <div class="layout column align-center main-background darken-1 pa-3 pt-6">
                   <img src="/static/assets/logo.svg" alt="Product Login Logo" width="180" height="180">
-                  <span class="flex my-4 primary--text text-h5 font-weight-light">{{ customSubheader }}</span>
+                  <span class="flex my-4 primary--text text-h4 font-weight-light">{{ productName }}</span>
+                  <span class="flex my-4 primary--text text-h5 font-weight-light">{{ productSlogan }}</span>
                 </div>
                 <v-tabs
                   v-show="!loading"
@@ -113,14 +114,15 @@ export default {
       token: '',
       loginType: undefined,
       cfg: {
+        productName: undefined,
+        productSlogan: undefined,
         documentationURL: undefined,
         supportURL: undefined,
         loginTypes: undefined,
         landingPageUrl: undefined,
         landingPageName: undefined,
         customLandingPagePre: undefined,
-        customLandingPagePost: undefined,
-        customSubheader: undefined
+        customLandingPagePost: undefined
       },
       loading: false
     }
@@ -135,6 +137,12 @@ export default {
     primaryLoginType () {
       return getPrimaryLoginType(this.cfg)
     },
+    productName () {
+      return this.cfg.productName || 'PSKE'
+    },
+    productSlogan () {
+      return this.cfg.productSlogan || 'Managed Kubernetes at Scale'
+    },
     documentationURL () {
       return this.cfg.documentationURL || 'https://docs.pske.get-cloud.io'
     },
@@ -146,9 +154,6 @@ export default {
     },
     landingPageName () {
       return this.cfg.landingPageName || 'PSKE'
-    },
-    customSubheader () {
-      return this.cfg.customSubheader || 'Managed Kubernetes'
     },
     customLandingPagePre () {
       return this.cfg.customLandingPagePre || 'Powered by'
@@ -170,6 +175,9 @@ export default {
       try {
         const { data } = await api.getLoginConfiguration()
         cfg = data
+        Object.keys(cfg).forEach(key => {
+          sessionStorage.setItem('wl.' + key, cfg[key])
+        })
       } catch (err) {
         logger.error('Failed to fetch login configuration: %s', err.message)
         cfg = {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
             <v-card class="elevation-1">
               <v-card-title class="pa-0">
                 <div class="layout column align-center main-background darken-1 pa-3 pt-6">
-                  <img src="/static/assets/logo.svg" alt="Login to PSKE" width="180" height="180">
+                  <img src="/static/assets/logo.svg" alt="Product Login Logo" width="180" height="180">
                   <span class="flex my-4 primary--text text-h5 font-weight-light">{{ customSubheader }}</span>
                 </div>
                 <v-tabs
@@ -60,7 +60,13 @@ SPDX-License-Identifier: Apache-2.0
               </v-card-text>
               <v-card-actions v-show="!loading" class="bt-2 pb-4">
                 <div class="d-flex justify-center flex-grow-1">
+                  <a :href="documentationURL" target="_blank" rel="noopener">Docs</a>
+                </div>
+                <div class="d-flex justify-center flex-grow-1">
                   <v-btn @click="handleLogin" color="primary">Login</v-btn>
+                </div>
+                <div class="d-flex justify-center flex-grow-1">
+                  <a :href="supportURL" target="_blank" rel="noopener">Support</a>
                 </div>
               </v-card-actions>
             </v-card>
@@ -107,6 +113,8 @@ export default {
       token: '',
       loginType: undefined,
       cfg: {
+        documentationURL: undefined,
+        supportURL: undefined,
         loginTypes: undefined,
         landingPageUrl: undefined,
         landingPageName: undefined,
@@ -126,6 +134,12 @@ export default {
     },
     primaryLoginType () {
       return getPrimaryLoginType(this.cfg)
+    },
+    documentationURL () {
+      return this.cfg.documentationURL || 'https://docs.pske.get-cloud.io'
+    },
+    supportURL () {
+      return this.cfg.supportURL || 'https://www.plusserver.com/ueber-uns/plusserver-kontakt'
     },
     landingPageUrl () {
       return this.cfg.landingPageUrl || 'https://plusserver.com/pske'


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow for Whitelabeling of Gardener Dashboards

**Which issue(s) this PR fixes**:
Fixes MK-1831

**Special notes for your reviewer**:
Requires combination of overwriting login-config.json and using the theming options of the custom helm chart

**Release note**:
No changes in usage.
Can also be used as the default dashboard
