### PR TITLE
Don't display static kubeconfig access option for cluster > 1.26

### DIFF
--- a/charts/gardener-dashboard/charts/utils-templates
+++ b/charts/gardener-dashboard/charts/utils-templates
@@ -1,1 +1,0 @@
-../../utils-templates

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -95,7 +95,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-divider v-if="isCredentialsTileVisible && (isKubeconfigTileVisible || isGardenctlTileVisible)" inset></v-divider>
 
     <v-list v-if="isKubeconfigTileVisible">
-      <shoot-kubeconfig :shoot-item="shootItem" :showIcon="false" type="token"></shoot-kubeconfig>
+      <shoot-kubeconfig v-if="supportsStaticKubeconfig"  :shoot-item="shootItem" :showIcon="false" type="token"></shoot-kubeconfig>
       <shoot-kubeconfig :shoot-item="shootItem" :showIcon="false" type="adminkubeconfig"></shoot-kubeconfig>
     </v-list>
 
@@ -234,6 +234,15 @@ export default {
     },
     visibilityIcon () {
       return this.showToken ? 'mdi-eye-off' : 'mdi-eye'
+    },
+    supportsStaticKubeconfig () {
+      // Check if k8s minor version is greater than 26 (1.26.x) -> Static kubeconfig isn't supported
+      const shootK8sVersion = get(this.shootItem, 'spec.kubernetes.version')
+      if (parseInt(shootK8sVersion.split('.')[1]) > 26) {
+        return false
+      }
+
+      return true
     }
   },
   methods: {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
